### PR TITLE
An attempt to fix the existing rspec tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,11 +59,11 @@ gem 'puma'
 gem 'silencer'
 gem 'newrelic_rpm'
 
-group :production do 
+group :production do
   gem 'rails_12factor'
 end
 
-group :development do 
+group :development do
   gem 'letter_opener'
   gem 'letter_opener_web'
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,3 +264,6 @@ DEPENDENCIES
   spring
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.11.2

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/spec/controllers/admin/projects_controller_spec.rb
+++ b/spec/controllers/admin/projects_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe ProjectsController do
+describe Admin::ProjectsController do
 
-  logged_in_user
+  logged_in_user_admin
 
   describe "GET #index" do
     it "populates an array of projects" do
@@ -39,7 +39,7 @@ describe ProjectsController do
 
       it "redirects to projects page" do
         post :create, project: attributes_for(:project)
-        response.should redirect_to projects_url
+        expect(response).to redirect_to(admin_projects_url)
       end
     end
 
@@ -95,7 +95,7 @@ describe ProjectsController do
 
       it "redirects to projects#index" do
         put :update, id: @project, project: attributes_for(:project)
-        response.should redirect_to projects_url
+        expect(response).to redirect_to(admin_projects_url)
       end
     end
 
@@ -128,7 +128,7 @@ describe ProjectsController do
 
     it "redirects to projects#index" do
       delete :destroy, id: @project
-      response.should redirect_to projects_url
+      expect(response).to redirect_to(admin_projects_url)
     end
   end
 end

--- a/spec/controllers/admin/tasks_controller_spec.rb
+++ b/spec/controllers/admin/tasks_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe TasksController do
+describe Admin::TasksController do
 
-  logged_in_user
+  logged_in_user_admin
 
   describe "GET #index" do
     it "assigns the list of tasks to @tasks" do
@@ -13,6 +13,7 @@ describe TasksController do
 
     it "renders the :index template" do
       get :index
+      expect(response.status).to eq(200)
       response.should render_template :index
     end
   end
@@ -55,7 +56,7 @@ describe TasksController do
 
       it "redirects to :index page" do
         post :create, task: attributes_for(:task)
-        response.should redirect_to tasks_url
+        expect(response).to redirect_to(admin_tasks_url)
       end
     end
 
@@ -95,7 +96,7 @@ describe TasksController do
 
       it "redirects to :index page" do
         put :update, id: @task, task: attributes_for(:task)
-        response.should redirect_to tasks_url
+        expect(response).to redirect_to(admin_tasks_url)
       end
     end
 
@@ -128,7 +129,7 @@ describe TasksController do
 
     it "redirects to :index page" do
       delete :destroy, id: @task
-      response.should redirect_to tasks_url
+      expect(response).to redirect_to(admin_tasks_url)
     end
   end
 end

--- a/spec/controllers/time_entries_controller_spec.rb
+++ b/spec/controllers/time_entries_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe TimeEntriesController do
+describe "TimeEntriesController" do
 
 end

--- a/spec/factories/time_entries.rb
+++ b/spec/factories/time_entries.rb
@@ -2,9 +2,9 @@
 
 FactoryGirl.define do
   factory :time_entry do
-    association             :user
-    association             :project
-    association             :task
+    association             :user, factory: :user
+    association             :project, factory: :project
+    association             :task, factory: :task
     entry_date              { Date.today }
     duration_in_hours       { rand * 10 }
     comments                { Faker::Lorem.sentence }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,15 +2,32 @@
 
 FactoryGirl.define do
   factory :user do
-    firstname   { Faker::Name.first_name }
-    lastname    { Faker::Name.last_name }
-    email       { Faker::Internet.safe_email }
-    password    { Faker::Internet.password }
+    firstname    { Faker::Name.first_name }
+    lastname     { Faker::Name.last_name }
+    email        { Faker::Internet.safe_email }
+    password     { Faker::Internet.password }
+    active       true
+    is_admin     false
+    hourly       false
+    rate         0.0
+    secondary_rate 0.0
+    holiday_rate_multiplier 1
+    password_reset_required false
+    company_name { Faker::Company.name }
+    tax_number   { Faker::Number.number(10) }
+    after(:build) { |user|
+      user.class.any_instance.stub(:send_email_invite)
+    }
+    trait :admin do
+      is_admin true
+    end
+
+    trait :invalid_email do
+      email { Faker::Name.name}
+    end
+
+    factory :user_admin, traits: [:admin]
+    factory :user_invalid_email, traits: [:invalid_email]
   end
-  factory :user_invalid_email, class: User do
-    firstname   { Faker::Name.first_name }
-    lastname    { Faker::Name.last_name }
-    email       { Faker::Name.name }
-    password    { Faker::Internet.password }
-  end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,7 +30,7 @@ describe User do
 
   describe "#fullname" do
     it "returns a concatenation of firstname and lastname" do
-      user = create(:user)
+      user = build(:user)
       expect(user.fullname).to eq "#{user.firstname} #{user.lastname}"
     end
   end

--- a/spec/support/user_account_helpers.rb
+++ b/spec/support/user_account_helpers.rb
@@ -9,6 +9,10 @@ module UserAccountHelpers
     def logged_in_user
       current_user { create(:user) }
     end
+
+    def logged_in_user_admin
+      current_user { create(:user_admin) }
+    end
   end
 
   def login_as(user)


### PR DESCRIPTION
- added support for factory creation of an admin for admin route testing
- moved old controller specs in to admin specs
- minor refactoring on factories

`bundler exec rspec spec` should be all green now.

We are missing controller tests on:
- /reports and /admin/reports
- /admin/users
- /api/**
- /time_entries
- /session
- /password*
- /home

All the models are equally behind on testing.
