### PR TITLE
Replace 'insanely' with 'incredibly' in show.html.erb

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -5,7 +5,7 @@
         <h2>
           Welcome to Clock Tower!
         </h2>
-        <p>Insanely simple time tracking.</p>
+        <p>Incredibly simple time tracking.</p>
       </div>
 
       <% if !is_logged_in? %>


### PR DESCRIPTION
Hi everyone,

I reported this issue to @interlock via email and he asked me to submit a PR with the correction. I noticed some ableist language on the splash page. I changed "[insanely](http://www.dictionary.com/browse/insanely)" to "[incredibly](http://www.dictionary.com/browse/incredibly)" since Clock Tower has nothing to do with being diagnosed with a serious mental illness. 

- Before: *Insanely simple time tracking.*
- Now: *Incredibly simple time tracking.*

Other words to avoid: http://thoughtcatalog.com/parker-marie-molloy/2013/10/15-crazy-examples-of-insanely-ableist-language/ I have only come across this one instance where an ableist word has been used, but I will submit more PRs if I come across any others. I also think this PR should be merged into the base repository too. Not sure if @asoesilo is still working on his version still though.

Cheers,

~~Willow